### PR TITLE
Update Nio4r to 2.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,9 @@ sudo: false
 language: ruby
 cache: bundler
 rvm:
-  - 2.0.0
-  - 2.1.9
   - 2.2.6
   - 2.3.3
+  - 2.4.0
 before_install:
   - "echo 'gem: --no-ri --no-rdoc --no-document' > ~/.gemrc"
   - "gem install bundler -v 1.13.0"

--- a/surro-gate.gemspec
+++ b/surro-gate.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'nio4r', '~> 1.2.0'
+  spec.add_dependency 'nio4r', '~> 2.0.0'
 
   spec.add_development_dependency 'bundler', '~> 1.13'
   spec.add_development_dependency 'codecov', '~> 0.1.0'


### PR DESCRIPTION
This drops support for Ruby versions under 2.2.2