### PR TITLE
Do not use the GVL when calling epoll_wait

### DIFF
--- a/ext/surro-gate/selector_ext.h
+++ b/ext/surro-gate/selector_ext.h
@@ -3,11 +3,21 @@
 
 #include "ruby.h"
 #include "ruby/io.h"
+#include "ruby/thread.h"
 #include "stdlib.h"
 #include "sys/epoll.h"
 
 #define SOCK_PTR(X) RFILE(X)->fptr->fd
 #define IVAR_TRUE(X, Y) rb_iv_get(X, Y) == Qtrue
+
+struct epoll_wait_args {
+  unsigned int epfd;
+  struct epoll_event *events;
+  int maxevents;
+  int timeout;
+
+  int result;
+};
 
 static VALUE SurroGate_Selector_allocate(VALUE self);
 static VALUE SurroGate_Selector_initialize(VALUE self, VALUE logger);


### PR DESCRIPTION
I organized the arguments and the return value of [`epoll_wait`](http://man7.org/linux/man-pages/man2/epoll_wait.2.html) into a structure that's being passed to `rb_thread_call_without_gvl` together with the `wait_func` that actually calls the `epoll_wait` after unpacking the arguments from the structure.

Fixes #16 

@kbrock can you please take a look?