### PR TITLE
Fixed epoll_rearm call argument order in pairing_iterate

### DIFF
--- a/ext/surro-gate/selector_ext.c
+++ b/ext/surro-gate/selector_ext.c
@@ -60,9 +60,9 @@ static VALUE pairing_iterate(VALUE pair, VALUE self, int argc, VALUE *argv) {
 
     Data_Get_Struct(self, int, selector);
     // Rearm left socket for reading and also writing if not ready for writing
-    epoll_rearm(selector, SOCK_PTR(rb_iv_get(pair, "@left")), NUM2INT(argv[1]), NUM2INT(inv_idx), EPOLLIN | (IVAR_TRUE(inverse, "@wr_rdy") ? 0 : EPOLLOUT));
+    epoll_rearm(selector, SOCK_PTR(rb_iv_get(pair, "@left")), NUM2INT(inv_idx), NUM2INT(argv[1]), EPOLLIN | (IVAR_TRUE(inverse, "@wr_rdy") ? 0 : EPOLLOUT));
     // Rearm right socket for writing and also reading if not ready for reading
-    epoll_rearm(selector, SOCK_PTR(rb_iv_get(pair, "@right")), NUM2INT(inv_idx), NUM2INT(argv[1]), EPOLLOUT | (IVAR_TRUE(inverse, "@rd_rdy") ? 0 : EPOLLIN));
+    epoll_rearm(selector, SOCK_PTR(rb_iv_get(pair, "@right")), NUM2INT(argv[1]), NUM2INT(inv_idx), EPOLLOUT | (IVAR_TRUE(inverse, "@rd_rdy") ? 0 : EPOLLIN));
   }
   return Qnil;
 }

--- a/ext/surro-gate/selector_ext.c
+++ b/ext/surro-gate/selector_ext.c
@@ -167,8 +167,8 @@ static VALUE SurroGate_Selector_select(VALUE self, VALUE timeout) {
     source = (int)((events[i].data.u64 & 0xFFFFFFFF00000000LL) >> 32);
     target = (int)(events[i].data.u64 & 0xFFFFFFFFLL);
 
-    read = rb_funcall(pairing, rb_intern("[]"), 1, INT2NUM(target)); // @pairing[source]
-    write = rb_funcall(pairing, rb_intern("[]"), 1, INT2NUM(source)); // @pairing[target]
+    read = rb_funcall(pairing, rb_intern("[]"), 1, INT2NUM(target)); // @pairing[target]
+    write = rb_funcall(pairing, rb_intern("[]"), 1, INT2NUM(source)); // @pairing[source]
 
     if (events[i].events & EPOLLIN && events[i].events & EPOLLOUT) {
       // Socket is both available for read and write

--- a/lib/surro-gate/version.rb
+++ b/lib/surro-gate/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 module SurroGate
-  VERSION = '1.0.1'.freeze
+  VERSION = '1.0.2'.freeze
   HAVE_EXT = RUBY_PLATFORM =~ /linux/ && !defined?(JRUBY_VERSION) && !ENV['SURRO_GATE_NOEXT']
 end

--- a/spec/surro-gate_spec.rb
+++ b/spec/surro-gate_spec.rb
@@ -41,6 +41,7 @@ describe SurroGate do
     end
 
     before do
+      thread.abort_on_exception = true
       proxy.push(sock_1.first, sock_2.first)
       sleep(2)
     end
@@ -52,11 +53,13 @@ describe SurroGate do
     end
 
     it 'transmits in both directions' do
-      sock_1.last.write_nonblock('foo')
-      sock_2.last.write_nonblock('bar')
-      sleep(2)
-      expect(sock_2.last.read_nonblock(3)).to eq('foo')
-      expect(sock_1.last.read_nonblock(3)).to eq('bar')
+      2.times do
+        sock_1.last.write_nonblock('foo')
+        sock_2.last.write_nonblock('bar')
+        sleep(2)
+        expect(sock_2.last.read_nonblock(3)).to eq('foo')
+        expect(sock_1.last.read_nonblock(3)).to eq('bar')
+      end
     end
   end
 end


### PR DESCRIPTION
The pairing arguments' order wasn't correct, the rearm was registering the opposite pairings and so the select was returning the readiness of the opposite sockets. I also updated the comments on the pairing selection in the `select` method and updated the tests a little.