### PR TITLE
 Do not expose the compilation rake task if the platform is not Linux

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -7,10 +7,14 @@ require 'surro-gate/version'
 
 RSpec::Core::RakeTask.new(:spec)
 
-Rake::ExtensionTask.new('surro-gate') do |ext|
-  ext.name = 'surro-gate/selector_ext'
-end
+if SurroGate::HAVE_EXT
+  Rake::ExtensionTask.new('surro-gate') do |ext|
+    ext.name = 'surro-gate/selector_ext'
+  end
 
-task :default => SurroGate::HAVE_EXT ? %i[compile spec] : %i[clean spec]
+  task :default => %i[compile spec]
+else
+  task :default => %i[clean spec]
+end
 
 CLEAN.include '**/*.o', '**/*.so', 'pkg', 'tmp'

--- a/lib/surro-gate/version.rb
+++ b/lib/surro-gate/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 module SurroGate
-  VERSION = '1.0.2'.freeze
+  VERSION = '1.0.3'.freeze
   HAVE_EXT = RUBY_PLATFORM =~ /linux/ && !defined?(JRUBY_VERSION) && !ENV['SURRO_GATE_NOEXT']
 end


### PR DESCRIPTION
Apparently it is not enough to omit the `extensions` line from the gemspec to prevent Rubygems from compiling...