### PR TITLE
Test the correct socket for readability if it is available for write

### DIFF
--- a/ext/surro-gate/selector_ext.c
+++ b/ext/surro-gate/selector_ext.c
@@ -184,7 +184,7 @@ static VALUE SurroGate_Selector_select(VALUE self, VALUE timeout) {
     } else if (events[i].events & EPOLLOUT) {
       // Socket is available for write, reregister it for read if not readable
       rb_iv_set(write, "@wr_rdy", Qtrue); // write.wr_rdy = true
-      if (rb_iv_get(write, "@rd_rdy") == Qfalse) { // if !source.rd_rdy
+      if (rb_iv_get(read, "@rd_rdy") == Qfalse) { // if !source.rd_rdy
         socket = rb_iv_get(write, "@right"); // write.right
         epoll_rearm(selector, SOCK_PTR(socket), source, target, EPOLLIN);
       }


### PR DESCRIPTION
This is a typo-ish mistake, the comment is correct and the code does something else. It did not cause any issues, because we hit only the most possible scenario, i.e. there is a high chance that the socket is ready for writing. However, a less possible scenario can still happen if the transmission speed is significantly different between the two sides of the proxy.

@kbrock this is not the bug I was talking about, just found it by accident as the code looked a little asymmetric.