### PR TITLE
Use a scoreboard-like struct for holding the pairing of sockets

### DIFF
--- a/ext/surro-gate/selector_ext.c
+++ b/ext/surro-gate/selector_ext.c
@@ -3,23 +3,24 @@
 static VALUE mSurroGate = Qnil;
 static VALUE cSurroGate_Selector = Qnil;
 static VALUE cSurroGate_Pair = Qnil;
+static VALUE cSurroGate_Scoreboard = Qnil;
 
-void epoll_register(int *epoll, int socket, int ltr, int rtl) {
+void epoll_register(int *epoll, VALUE socket) {
   struct epoll_event ev;
-  ev.data.u64 = ((uint64_t)ltr) << 32 | rtl;
+  ev.data.u64 = (uint64_t) socket;
   ev.events = EPOLLONESHOT | EPOLLIN | EPOLLOUT;
-  epoll_ctl(*epoll, EPOLL_CTL_ADD, socket, &ev);
+  epoll_ctl(*epoll, EPOLL_CTL_ADD, SOCK_PTR(socket), &ev);
 }
 
-void epoll_deregister(int *epoll, int socket) {
-  epoll_ctl(*epoll, EPOLL_CTL_DEL, socket, NULL);
+void epoll_deregister(int *epoll, VALUE socket) {
+  epoll_ctl(*epoll, EPOLL_CTL_DEL, SOCK_PTR(socket), NULL);
 }
 
-void epoll_rearm(int *epoll, int socket, int ltr, int rtl, int events) {
+void epoll_rearm(int *epoll, VALUE socket, int events) {
   struct epoll_event ev;
-  ev.data.u64 = ((uint64_t)ltr) << 32 | rtl;
+  ev.data.u64 = (uint64_t) socket;
   ev.events = EPOLLONESHOT | events;
-  epoll_ctl(*epoll, EPOLL_CTL_MOD, socket, &ev);
+  epoll_ctl(*epoll, EPOLL_CTL_MOD, SOCK_PTR(socket), &ev);
 }
 
 void* wait_func(void *ptr) {
@@ -29,40 +30,25 @@ void* wait_func(void *ptr) {
   return NULL;
 }
 
-static VALUE pairing_compare(VALUE pair, VALUE sockets) {
-  int i;
-  VALUE left = rb_iv_get(pair, "@left");
-  VALUE right = rb_iv_get(pair, "@right");
-
-  for (i=0; i<RARRAY_LEN(sockets); i++) { // sockets.each
-    VALUE item = rb_ary_entry(sockets, i);
-    if (left == item || right == item) {
-      return Qtrue;
-    }
-  }
-
-  return Qnil;
-};
-
-static VALUE pairing_iterate(VALUE pair, VALUE self, int argc, VALUE *argv) {
+static VALUE scoreboard_iterate(VALUE pair, VALUE self, int argc, VALUE *argv) {
   int *selector;
-  VALUE inverse, inv_idx;
+  VALUE inverse;
+
+  VALUE scoreboard = rb_iv_get(self, "@scoreboard");
+  Data_Get_Struct(self, int, selector);
 
   // Yield only for the pairs that are ready
   if (rb_funcall(pair, rb_intern("ready?"), 0) == Qtrue) {
     rb_yield_values(2, rb_iv_get(pair, "@left"), rb_iv_get(pair, "@right")); // yield(pair.left, pair.right)
 
-    inv_idx = rb_iv_get(pair, "@inverse");
-    inverse = rb_funcall(rb_iv_get(self, "@pairing"), rb_intern("[]"), 1, inv_idx); // @pairing[inv_idx]
-
-    rb_iv_set(pair, "@rd_rdy", Qfalse);
-    rb_iv_set(pair, "@wr_rdy", Qfalse);
-
-    Data_Get_Struct(self, int, selector);
+    // Unmark the readiness of the socket pair
+    rb_funcall(pair, rb_intern("unmark"), 0);
+    // Get the inverse socket pairing of the current one
+    inverse = rb_funcall(scoreboard, rb_intern("inverse"), 1, pair);
     // Rearm left socket for reading and also writing if not ready for writing
-    epoll_rearm(selector, SOCK_PTR(rb_iv_get(pair, "@left")), NUM2INT(inv_idx), NUM2INT(argv[1]), EPOLLIN | (IVAR_TRUE(inverse, "@wr_rdy") ? 0 : EPOLLOUT));
+    epoll_rearm(selector, rb_iv_get(pair, "@left"), EPOLLIN | (IVAR_TRUE(inverse, "@wr_rdy") ? 0 : EPOLLOUT));
     // Rearm right socket for writing and also reading if not ready for reading
-    epoll_rearm(selector, SOCK_PTR(rb_iv_get(pair, "@right")), NUM2INT(argv[1]), NUM2INT(inv_idx), EPOLLOUT | (IVAR_TRUE(inverse, "@rd_rdy") ? 0 : EPOLLIN));
+    epoll_rearm(selector, rb_iv_get(pair, "@right"), EPOLLOUT | (IVAR_TRUE(inverse, "@rd_rdy") ? 0 : EPOLLIN));
   }
   return Qnil;
 }
@@ -89,69 +75,54 @@ static void SurroGate_Selector_free(int *selector) {
 }
 
 static VALUE SurroGate_Selector_initialize(VALUE self, VALUE logger) {
-  VALUE mConcurrent = rb_const_get(rb_cObject, rb_intern("Concurrent"));
-  VALUE cArray = rb_const_get(mConcurrent, rb_intern("Array"));
-
-  rb_iv_set(self, "@pairing", rb_class_new_instance(0, NULL, cArray)); // @pairing = Concurrent::Array.new
+  rb_iv_set(self, "@scoreboard", rb_class_new_instance(0, NULL, cSurroGate_Scoreboard)); // @scoreboard = Scoreboard.new
   rb_iv_set(self, "@logger", logger);
 
   return Qnil;
 }
 
 static VALUE SurroGate_Selector_push(VALUE self, VALUE left, VALUE right) {
-  int index_ltr, index_rtl, *selector;
+  int *selector;
+  VALUE scoreboard = rb_iv_get(self, "@scoreboard");
 
-  VALUE pair_LTR[2] = {left, right};
-  VALUE pair_RTL[2] = {right, left};
-  VALUE left_to_right = rb_class_new_instance(2, pair_RTL, cSurroGate_Pair); // SurroGate::Pair.new(left, right)
-  VALUE right_to_left = rb_class_new_instance(2, pair_LTR, cSurroGate_Pair); // SurroGate::Pair.new(right, left)
-
-  VALUE pairing = rb_iv_get(self, "@pairing");
-
+  // Check the arguments for the correct type
   Check_Type(left, T_FILE);
   Check_Type(right, T_FILE);
 
-  // raise ArgumentError if @pairing.detect(&pairing_compare)
-  if (rb_block_call(pairing, rb_intern("detect"), 0, NULL, pairing_compare, rb_ary_new_from_values(2, pair_LTR)) != Qnil) {
+  // raise ArgumentError if a socket is already registered
+  if (rb_funcall(scoreboard, rb_intern("include?"), 1, left) == Qtrue || rb_funcall(scoreboard, rb_intern("include?"), 1, right) == Qtrue) {
     rb_raise(rb_eArgError, "Socket already registered!");
   }
 
   Data_Get_Struct(self, int, selector);
+  rb_funcall(scoreboard, rb_intern("push"), 2, left, right);
 
-  rb_funcall(pairing, rb_intern("push"), 2, left_to_right, right_to_left); // @pairing.push(left_to_right, right_to_left)
-  index_ltr = NUM2INT(rb_funcall(pairing, rb_intern("index"), 1, left_to_right)); // @pairing.index(left_to_right)
-  index_rtl = NUM2INT(rb_funcall(pairing, rb_intern("index"), 1, right_to_left)); // @pairing.index(right_to_left)
-
-  rb_iv_set(left_to_right, "@inverse", INT2NUM(index_rtl));
-  rb_iv_set(right_to_left, "@inverse", INT2NUM(index_ltr));
-
-  epoll_register(selector, SOCK_PTR(left), index_ltr, index_rtl);
-  epoll_register(selector, SOCK_PTR(right), index_rtl, index_ltr);
+  epoll_register(selector, left);
+  epoll_register(selector, right);
 
   return Qtrue;
 }
 
-static VALUE SurroGate_Selector_pop(VALUE self, VALUE sockets) {
-  int i, *selector;
+static VALUE SurroGate_Selector_pop(VALUE self, VALUE left, VALUE right) {
+  int *selector;
 
-  VALUE pairing = rb_iv_get(self, "@pairing");
-  rb_block_call(pairing, rb_intern("delete_if"), 0, NULL, pairing_compare, sockets); // @pairing.delete_if(&pairing_compare)
+  VALUE scoreboard = rb_iv_get(self, "@scoreboard");
+  rb_funcall(scoreboard, rb_intern("pop"), 2, left, right);
 
   Data_Get_Struct(self, int, selector);
-  for (i=0; i<RARRAY_LEN(sockets); i++) {
-    epoll_deregister(selector, SOCK_PTR(rb_ary_entry(sockets, i)));
-  }
+  epoll_deregister(selector, left);
+  epoll_deregister(selector, right);
 
   return Qnil;
 }
 
 static VALUE SurroGate_Selector_select(VALUE self, VALUE timeout) {
-  int i, *selector, source, target;
+  int i, *selector;
   struct epoll_event events[256];
   struct epoll_wait_args wait_args;
-  VALUE read, write, socket;
+  VALUE socket;
 
-  VALUE pairing = rb_iv_get(self, "@pairing");
+  VALUE scoreboard = rb_iv_get(self, "@scoreboard");
   Data_Get_Struct(self, int, selector);
 
   // The code after the comments has the same result as the code below, but with GVL
@@ -164,29 +135,23 @@ static VALUE SurroGate_Selector_select(VALUE self, VALUE timeout) {
   rb_thread_call_without_gvl(wait_func, &wait_args, NULL, NULL);
 
   for (i=0; i<wait_args.result; i++) {
-    source = (int)((events[i].data.u64 & 0xFFFFFFFF00000000LL) >> 32);
-    target = (int)(events[i].data.u64 & 0xFFFFFFFFLL);
-
-    read = rb_funcall(pairing, rb_intern("[]"), 1, INT2NUM(target)); // @pairing[target]
-    write = rb_funcall(pairing, rb_intern("[]"), 1, INT2NUM(source)); // @pairing[source]
+    socket = (VALUE) events[i].data.u64;
 
     if (events[i].events & EPOLLIN && events[i].events & EPOLLOUT) {
       // Socket is both available for read and write
-      rb_iv_set(read, "@rd_rdy", Qtrue); // read.rd_rdy = true
-      rb_iv_set(write, "@wr_rdy", Qtrue); // write.wr_rdy = true
+      rb_funcall(scoreboard, rb_intern("mark_rd"), 1, socket);
+      rb_funcall(scoreboard, rb_intern("mark_wr"), 1, socket);
     } else if (events[i].events & EPOLLIN) {
       // Socket is available for read, reregister it for write if not writable
-      rb_iv_set(read, "@rd_rdy", Qtrue); // read.rd_rdy = true
-      if (rb_iv_get(write, "@wr_rdy") == Qfalse) { // if !write.wr_rdy
-        socket = rb_iv_get(read, "@left"); // read.left
-        epoll_rearm(selector, SOCK_PTR(socket), target, source, EPOLLOUT);
+      rb_funcall(scoreboard, rb_intern("mark_rd"), 1, socket);
+      if (rb_funcall(scoreboard, rb_intern("marked_wr?"), 1, socket) == Qfalse) {
+        epoll_rearm(selector, socket, EPOLLOUT);
       }
     } else if (events[i].events & EPOLLOUT) {
       // Socket is available for write, reregister it for read if not readable
-      rb_iv_set(write, "@wr_rdy", Qtrue); // write.wr_rdy = true
-      if (rb_iv_get(read, "@rd_rdy") == Qfalse) { // if !source.rd_rdy
-        socket = rb_iv_get(write, "@right"); // write.right
-        epoll_rearm(selector, SOCK_PTR(socket), source, target, EPOLLIN);
+      rb_funcall(scoreboard, rb_intern("mark_wr"), 1, socket);
+      if (rb_funcall(scoreboard, rb_intern("marked_rd?"), 1, socket) == Qfalse) {
+        epoll_rearm(selector, socket, EPOLLIN);
       }
     }
   }
@@ -195,24 +160,25 @@ static VALUE SurroGate_Selector_select(VALUE self, VALUE timeout) {
 }
 
 static VALUE SurroGate_Selector_each_ready(VALUE self) {
-  VALUE pairing = rb_iv_get(self, "@pairing");
+  VALUE scoreboard = rb_iv_get(self, "@scoreboard");
   rb_need_block();
-  return rb_block_call(pairing, rb_intern("each_with_index"), 0, NULL, pairing_iterate, self);
+  return rb_block_call(scoreboard, rb_intern("each"), 0, NULL, scoreboard_iterate, self);
 }
 
 void Init_selector_ext() {
-  rb_require("concurrent");
   rb_require("surro-gate/pair");
+  rb_require("surro-gate/scoreboard");
 
   mSurroGate = rb_define_module("SurroGate");
   cSurroGate_Selector = rb_define_class_under(mSurroGate, "Selector", rb_cObject);
   cSurroGate_Pair = rb_const_get(mSurroGate, rb_intern("Pair"));
+  cSurroGate_Scoreboard = rb_const_get(mSurroGate, rb_intern("Scoreboard"));
 
   rb_define_alloc_func(cSurroGate_Selector, SurroGate_Selector_allocate);
 
   rb_define_method(cSurroGate_Selector, "initialize", SurroGate_Selector_initialize, 1);
   rb_define_method(cSurroGate_Selector, "push", SurroGate_Selector_push, 2);
-  rb_define_method(cSurroGate_Selector, "pop", SurroGate_Selector_pop, -2);
+  rb_define_method(cSurroGate_Selector, "pop", SurroGate_Selector_pop, 2);
   rb_define_method(cSurroGate_Selector, "select", SurroGate_Selector_select, 1);
   rb_define_method(cSurroGate_Selector, "each_ready", SurroGate_Selector_each_ready, 0);
 }

--- a/ext/surro-gate/selector_ext.h
+++ b/ext/surro-gate/selector_ext.h
@@ -26,7 +26,6 @@ static VALUE SurroGate_Selector_select(VALUE self, VALUE timeout);
 static VALUE SurroGate_Selector_each_ready(VALUE self);
 
 static void SurroGate_Selector_free(int *epoll);
-static VALUE pairing_compare(VALUE pair, VALUE sockets);
-static VALUE pairing_iterate(VALUE pair, VALUE self, int argc, VALUE *argv);
+static VALUE scoreboard_iterate(VALUE pair, VALUE self, int argc, VALUE *argv);
 
 #endif

--- a/lib/surro-gate/pair.rb
+++ b/lib/surro-gate/pair.rb
@@ -7,11 +7,31 @@ module SurroGate
     def initialize(left, right)
       @left = left
       @right = right
-      @rd_rdy = @wr_rdy = false
+      unmark
     end
 
     def ready?
       @rd_rdy && @wr_rdy || @left.closed? || @right.closed?
+    end
+
+    def marked_rd?
+      @rd_rdy
+    end
+
+    def marked_wr?
+      @wr_rdy
+    end
+
+    def mark_rd
+      @rd_rdy = true
+    end
+
+    def mark_wr
+      @wr_rdy = true
+    end
+
+    def unmark
+      @rd_rdy = @wr_rdy = false
     end
   end
 end

--- a/lib/surro-gate/scoreboard.rb
+++ b/lib/surro-gate/scoreboard.rb
@@ -1,0 +1,70 @@
+require 'thread'
+
+module SurroGate
+  class Scoreboard
+    def initialize
+      @rd = {}
+      @wr = {}
+
+      @lock = Mutex.new
+    end
+
+    def push(left, right)
+      left_to_right = Pair.new(left, right)
+      right_to_left = Pair.new(right, left)
+
+      @lock.synchronize do
+        @rd[left] = left_to_right
+        @wr[right] = left_to_right
+
+        @rd[right] = right_to_left
+        @wr[left] = right_to_left
+      end
+
+      [left, right]
+    end
+
+    def pop(left, right)
+      @lock.synchronize do
+        @rd.delete(left)
+        @rd.delete(right)
+        @wr.delete(left)
+        @wr.delete(right)
+      end
+
+      [left, right]
+    end
+
+    def mark_rd(sock)
+      @rd[sock].mark_rd
+    end
+
+    def mark_wr(sock)
+      @wr[sock].mark_wr
+    end
+
+    def marked_rd?(sock)
+      @rd[sock].marked_rd?
+    end
+
+    def marked_wr?(sock)
+      @wr[sock].marked_wr?
+    end
+
+    def unmark(sock)
+      @rd[sock].unmark
+    end
+
+    def include?(sock)
+      @rd.key?(sock) || @wr.key?(sock)
+    end
+
+    def each(&block)
+      @rd.values.each(&block)
+    end
+
+    def inverse(pair)
+      @wr[pair.left]
+    end
+  end
+end

--- a/lib/surro-gate/selector.rb
+++ b/lib/surro-gate/selector.rb
@@ -97,8 +97,8 @@ module SurroGate
     end
 
     def pairing_compare(pair, sockets)
-      sockets.each do |sock|
-        return true if [pair.left, pair.right].include?(sock)
+      sockets.any? do |sock|
+        pair.left == sock || pair.right == sock
       end
     end
   end

--- a/spec/surro-gate/selector_spec.rb
+++ b/spec/surro-gate/selector_spec.rb
@@ -8,6 +8,7 @@ describe SurroGate::Selector do
   let(:left_pair) { pairing.find { |pair| pair.instance_variable_get(:@left) == sockpair.first } }
   let(:right_pair) { pairing.find { |pair| pair.instance_variable_get(:@right) == sockpair.first } }
   let(:sockpair) { Socket.pair(:UNIX, :DGRAM, 0) }
+  let(:pipe) { IO.pipe }
 
   describe '#push' do
     context 'repushing arguments' do
@@ -40,6 +41,13 @@ describe SurroGate::Selector do
       subject.pop(*sockpair)
       expect(pairing.length).to eq(0)
     end
+
+    it 'handles out of order cleanup' do
+      subject.push(*pipe)
+      subject.pop(*sockpair)
+
+      expect { subject.select(500) }.to_not raise_error
+     end
   end
 
   describe '#select' do

--- a/spec/surro-gate/selector_spec.rb
+++ b/spec/surro-gate/selector_spec.rb
@@ -5,10 +5,25 @@ describe SurroGate::Selector do
 
   let(:logger) { double }
   let(:pairing) { subject.instance_variable_get(:@pairing) }
-  let(:left_pair) { pairing.find { |pair| pair.instance_variable_get(:@left) == sockpair.first } }
-  let(:right_pair) { pairing.find { |pair| pair.instance_variable_get(:@right) == sockpair.first } }
+  let(:map_rd) { subject.instance_variable_get(:@scoreboard).instance_variable_get(:@rd) }
+  let(:map_wr) { subject.instance_variable_get(:@scoreboard).instance_variable_get(:@wr) }
   let(:sockpair) { Socket.pair(:UNIX, :DGRAM, 0) }
-  let(:pipe) { IO.pipe }
+
+  let(:left_pair) do
+    if SurroGate::HAVE_EXT
+      map_rd[sockpair.first]
+    else
+      pairing.find { |pair| pair.instance_variable_get(:@left) == sockpair.first }
+    end
+  end
+
+  let(:right_pair) do
+    if SurroGate::HAVE_EXT
+      map_wr[sockpair.first]
+    else
+      pairing.find { |pair| pair.instance_variable_get(:@right) == sockpair.first }
+    end
+  end
 
   describe '#push' do
     context 'repushing arguments' do
@@ -27,19 +42,20 @@ describe SurroGate::Selector do
     end
 
     it 'stores the socket pair' do
-      expect(pairing.length).to eq(0)
+      expect_selector_length(0)
       subject.push(*sockpair)
-      expect(pairing.length).to eq(2)
+      expect_selector_length(2)
     end
   end
 
   describe '#pop' do
+    let(:pipe) { IO.pipe }
     before { subject.push(*sockpair) }
 
     it 'removes the socket pair' do
-      expect(pairing.length).to eq(2)
+      expect_selector_length(2)
       subject.pop(*sockpair)
-      expect(pairing.length).to eq(0)
+      expect_selector_length(0)
     end
 
     it 'handles out of order cleanup' do
@@ -157,6 +173,16 @@ describe SurroGate::Selector do
         expect(left_pair.ready?).to be_truthy
         expect(right_pair.ready?).to be_truthy
       end
+    end
+  end
+
+  # Helper method to determine the number of the registered sockets
+  def expect_selector_length(length)
+    if SurroGate::HAVE_EXT
+      expect(map_rd.length).to eq(length)
+      expect(map_wr.length).to eq(length)
+    else
+      expect(pairing.length).to eq(length)
     end
   end
 end


### PR DESCRIPTION
Using an indexed array and expecting the indexes not to change was a very strange idea but somehow I thought it can work. I'm mad enough at my past self, so you don't have to be.

So instead of the pairing array, I'm creating a double-indexed hash functioning as a scoreboard. You can access the pairing both through the reader and the writer sockets. This isn't really doable using the concurrent hash, as we need to run multiple operations exclusively together. So I'm using a mutex instead. The whole scoreboard has been written in Ruby, so the C code became significantly less complex.

I am planning to refactor the pure Ruby implementation to use the scoreboard as well, so the specs will be much simpler.