### PR TITLE
Fix incompatible pointer type in `SurroGate_Selector_each_ready`

### DIFF
--- a/ext/surro-gate/selector_ext.c
+++ b/ext/surro-gate/selector_ext.c
@@ -30,7 +30,7 @@ void* wait_func(void *ptr) {
   return NULL;
 }
 
-static VALUE scoreboard_iterate(VALUE pair, VALUE self, int argc, VALUE *argv) {
+static VALUE scoreboard_iterate(VALUE pair, VALUE self, int argc, const VALUE *argv, VALUE _blockarg) {
   int *selector;
   VALUE inverse;
 

--- a/ext/surro-gate/selector_ext.h
+++ b/ext/surro-gate/selector_ext.h
@@ -26,6 +26,6 @@ static VALUE SurroGate_Selector_select(VALUE self, VALUE timeout);
 static VALUE SurroGate_Selector_each_ready(VALUE self);
 
 static void SurroGate_Selector_free(int *epoll);
-static VALUE scoreboard_iterate(VALUE pair, VALUE self, int argc, VALUE *argv);
+static VALUE scoreboard_iterate(VALUE pair, VALUE self, int argc, const VALUE *argv, VALUE _blockarg);
 
 #endif


### PR DESCRIPTION
`rb_block_call_func_t` is of type `VALUE (*)(VALUE, VALUE, int, const VALUE *, VALUE)`

```
../../../../../ext/surro-gate/selector_ext.c: In function ‘SurroGate_Selector_each_ready’:
../../../../../ext/surro-gate/selector_ext.c:165:64: error: passing argument 5 of ‘rb_block_call’ from incompatible pointer type [-Wincompatible-pointer-types]
  165 |   return rb_block_call(scoreboard, rb_intern("each"), 0, NULL, scoreboard_iterate, self);
      |                                                                ^~~~~~~~~~~~~~~~~~
      |                                                                |
      |                                                                VALUE (*)(VALUE,  VALUE,  int,  VALUE *) {aka long unsigned int (*)(long unsigned int,  long unsigned int,  int,  long unsigned int *)}
In file included from /usr/include/ruby-3.3.0/ruby/ruby.h:41:
/usr/include/ruby-3.3.0/ruby/internal/iterator.h:324:90: note: expected ‘rb_block_call_func_t’ {aka ‘long unsigned int (*)(long unsigned int,  long unsigned int,  int,  const long unsigned int *, long unsigned int)’} but argument is of type ‘VALUE (*)(VALUE,  VALUE,  int,  VALUE *)’ {aka ‘long unsigned int (*)(long unsigned int,  long unsigned int,  int,  long unsigned int *)’}
  324 | VALUE rb_block_call(VALUE obj, ID mid, int argc, const VALUE *argv, rb_block_call_func_t proc, VALUE data2);
      |                                                                     ~~~~~~~~~~~~~~~~~~~~~^~~~
gmake: *** [Makefile:248: selector_ext.o] Error 1
rake aborted!
Command failed with status (2): [/usr/bin/gmake]
```